### PR TITLE
Replace unicode for '?'

### DIFF
--- a/stmcli/stmcli.py
+++ b/stmcli/stmcli.py
@@ -92,13 +92,13 @@ def main():
         bus_stops = printinfo.all_bus_stop(args.bus_number, db_file)
 
         for i in bus_stops:
-            print(i)
+            print(i.encode('ascii', 'replace'))
 
     elif args.bus_stop_code:
         # Print all bus for a stop code
         bus = printinfo.all_bus_for_stop_code(args.bus_stop_code, db_file)
 
         for i in bus:
-            print(i)
+            print(i.encode('ascii', 'replace'))
 
 main()


### PR DESCRIPTION
ex: [Ch?teauneuf / Des Ormeaux] 54623
instead of : UnicodeEncodeError: 'ascii' codec can't encode character '\xe9' in position 25: ordinal not in range(128)
