### PR TITLE
No more unicode crash, replace unicode for '?' char. ISSUE #9

### DIFF
--- a/stmcli/stmcli.py
+++ b/stmcli/stmcli.py
@@ -92,7 +92,7 @@ def main():
         bus_stops = printinfo.all_bus_stop(args.bus_number, db_file)
 
         for i in bus_stops:
-            print(i.encode('ascii').decode('utf-8'))
+            print(i.encode('ascii', 'replace').decode('utf-8'))
 
     elif args.bus_stop_code:
         # Print all bus for a stop code

--- a/stmcli/stmcli.py
+++ b/stmcli/stmcli.py
@@ -92,13 +92,13 @@ def main():
         bus_stops = printinfo.all_bus_stop(args.bus_number, db_file)
 
         for i in bus_stops:
-            print(i)
+            print(i.encode('ascii', 'replace'))
 
     elif args.bus_stop_code:
         # Print all bus for a stop code
         bus = printinfo.all_bus_for_stop_code(args.bus_stop_code, db_file)
 
         for i in bus:
-            print(i)
+            print(i.encode('ascii', 'replace'))
 
 main()

--- a/stmcli/stmcli.py
+++ b/stmcli/stmcli.py
@@ -92,13 +92,13 @@ def main():
         bus_stops = printinfo.all_bus_stop(args.bus_number, db_file)
 
         for i in bus_stops:
-            print(i.encode('ascii', 'replace'))
+            print(i.encode('ascii').decode('utf-8'))
 
     elif args.bus_stop_code:
         # Print all bus for a stop code
         bus = printinfo.all_bus_for_stop_code(args.bus_stop_code, db_file)
 
         for i in bus:
-            print(i.encode('ascii', 'replace'))
+            print(i.encode('ascii', 'replace').decode('utf-8'))
 
 main()


### PR DESCRIPTION
get:
    [Ch?teauneuf / de Vaujours] 54608
instead of:
    UnicodeEncodeError: 'ascii' codec can't encode character '\xe9' in position 25: ordinal not in range(128)
